### PR TITLE
115 name days shows day after todays names

### DIFF
--- a/src/js/welcome.js
+++ b/src/js/welcome.js
@@ -44,6 +44,9 @@ function renderSpecialDayInfo(res) {
     .classList.add("holidayInfo");
 
   const holidayDiv = document.querySelector(".holidayInfo");
-  holidayDiv.innerHTML =
-    "Dagens namn: " + daysArray[dateNow.getDate() - 1].namnsdag;
+  const names = daysArray[dateNow.getDate() - 1].namnsdag;
+  if (names.length > 0) {
+    holidayDiv.innerHTML =
+      "Dagens namn: " + names;
+  }
 }


### PR DESCRIPTION
Shows correct names now & hides namedays if there are no names of the day (like 24th June midsummer/new years day).